### PR TITLE
fix(fill): Next Style Uses Adjacent Fill Style for Next Ref

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -666,7 +666,7 @@ Style strings are a list of words, separated by whitespace. The words are not ca
 - `none`
 
 where `<color>` is a color specifier (discussed below). `fg:<color>` and `<color>` currently do the same thing, though this may change in the future.
-`<color>` can also be set to `prev_fg`, `prev_bg`, `next_fg` or `next_bg`, which evaluates to, respectively, the previous and next item's foreground or background color if available or `none` otherwise. `prev_fg` and `prev_bg` can be used transitively, whereas `next_fg` and `next_bg` cannot be used transitively.
+`<color>` can also be set to `prev_fg`, `prev_bg`, `next_fg` or `next_bg`, which evaluates to, respectively, the previous and next item's foreground or background color if available or `none` otherwise. `prev_fg` and `prev_bg` can be used transitively. `next_fg` and `next_bg` can resolve the next item's `prev_fg` and `prev_bg` references, but do not resolve further `next_fg` and `next_bg` references transitively.
 `inverted` swaps the background and foreground colors. The order of words in the string does not matter.
 
 The `none` token overrides all other tokens in a string if it is not part of a `bg:` specifier, so that e.g. `fg:red none fg:blue` will still create a string with no styling. `bg:none` sets the background to the default color so `fg:red bg:none` is equivalent to `red` or `fg:red` and `bg:green fg:red bg:none` is also equivalent to `fg:red` or `red`. It may become an error to use `none` in conjunction with other tokens in the future.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1080,6 +1080,30 @@ mod tests {
     }
 
     #[test]
+    fn table_get_styles_keep_fallback_when_ref_side_is_missing() {
+        let prev_style = AnsiStyle::new().fg(Color::Yellow).on(Color::Red);
+        let next_style = AnsiStyle::new().fg(Color::Blue).on(Color::Cyan);
+
+        let next_ref_with_fallback =
+            <StyleWrapper>::from_config(&Value::from("fg:black fg:next_bg bg:next_fg"))
+                .unwrap()
+                .0;
+        assert_eq!(
+            next_ref_with_fallback.to_ansi_style(Some(StyleRefs::new(Some(prev_style), None))),
+            AnsiStyle::new().fg(Color::Black)
+        );
+
+        let prev_ref_with_fallback =
+            <StyleWrapper>::from_config(&Value::from("fg:black fg:prev_bg bg:prev_fg"))
+                .unwrap()
+                .0;
+        assert_eq!(
+            prev_ref_with_fallback.to_ansi_style(Some(StyleRefs::new(None, Some(next_style)))),
+            AnsiStyle::new().fg(Color::Black)
+        );
+    }
+
+    #[test]
     fn table_get_styles_ordered() {
         // Test a background style with inverted order (also test hex + ANSI)
         let config = Value::from("bg:#050505 underline fg:120");

--- a/src/module.rs
+++ b/src/module.rs
@@ -220,7 +220,10 @@ where
             }
             _ => {
                 used += segment.width_graphemes();
-                let next_style = segments.peek().and_then(|s| s.style());
+                let current_base_style = segment.style_with_prev(prev_style);
+                let next_style = segments
+                    .peek()
+                    .and_then(|s| s.style_with_prev(current_base_style));
 
                 let style_refs = StyleRefs::new(prev_style, next_style);
                 let current_segment_string = segment.ansi_string(Some(style_refs));
@@ -256,10 +259,11 @@ where
 
         let wanted_len = fill_size.map(|s| s + fill_slack);
         prev_style = strs.last().map(|s| *s.style_ref());
+        let fill_base_style = fill.style_with_refs(Some(StyleRefs::new(prev_style, None)));
         let next_style = if let Some((s, next_fill)) = chunk_iter.peek() {
             s.first()
                 .map(|s| *s.style_ref())
-                .or_else(|| next_fill.style())
+                .or_else(|| next_fill.style_with_refs(Some(StyleRefs::new(fill_base_style, None))))
         } else {
             // For the last fill there is no next chunk; the trailing text is in `current`.
             current.first().map(|s| *s.style_ref())
@@ -402,6 +406,33 @@ mod tests {
             Color::Blue.paint("..."),
             nu_ansi_term::Style::new().on(Color::Blue).paint("--"),
             nu_ansi_term::Style::new().on(Color::Green).paint("B"),
+        ])
+        .to_string();
+        assert_eq!(combined, expected);
+    }
+
+    #[test]
+    fn test_next_style_resolves_next_prev_style_refs() {
+        let mut module = Module::new("unit_test", "This is a unit test", None);
+        module.set_segments(vec![
+            Segment::from_text(parse_style_string("fg:blue bg:next_fg", None), ">")
+                .into_iter()
+                .next()
+                .unwrap(),
+            Segment::from_text(parse_style_string("fg:prev_fg", None), ")")
+                .into_iter()
+                .next()
+                .unwrap(),
+        ]);
+
+        let rendered = module.ansi_strings_for_width(None);
+        let combined = AnsiStrings(&rendered).to_string();
+        let expected = AnsiStrings(&[
+            nu_ansi_term::Style::new()
+                .fg(Color::Blue)
+                .on(Color::Blue)
+                .paint(">"),
+            Color::Blue.paint(")"),
         ])
         .to_string();
         assert_eq!(combined, expected);

--- a/src/module.rs
+++ b/src/module.rs
@@ -256,8 +256,10 @@ where
 
         let wanted_len = fill_size.map(|s| s + fill_slack);
         prev_style = strs.last().map(|s| *s.style_ref());
-        let next_style = if let Some((s, _)) = chunk_iter.peek() {
-            s.first().map(|s| *s.style_ref())
+        let next_style = if let Some((s, next_fill)) = chunk_iter.peek() {
+            s.first()
+                .map(|s| *s.style_ref())
+                .or_else(|| next_fill.style())
         } else {
             // For the last fill there is no next chunk; the trailing text is in `current`.
             current.first().map(|s| *s.style_ref())
@@ -372,6 +374,34 @@ mod tests {
             Color::Red.paint("A"),
             Color::Blue.paint("...."),
             nu_ansi_term::Style::new().on(Color::Blue).paint("B"),
+        ])
+        .to_string();
+        assert_eq!(combined, expected);
+    }
+
+    #[test]
+    fn test_fill_segment_resolves_next_style_from_adjacent_fill() {
+        let mut module = Module::new("unit_test", "This is a unit test", None);
+        module.set_segments(vec![
+            Segment::from_text(parse_style_string("fg:red", None), "A")
+                .into_iter()
+                .next()
+                .unwrap(),
+            Segment::fill(parse_style_string("fg:next_bg", None), "."),
+            Segment::fill(parse_style_string("bg:blue", None), "-"),
+            Segment::from_text(parse_style_string("bg:green", None), "B")
+                .into_iter()
+                .next()
+                .unwrap(),
+        ]);
+
+        let rendered = module.ansi_strings_for_width(Some(7));
+        let combined = AnsiStrings(&rendered).to_string();
+        let expected = AnsiStrings(&[
+            Color::Red.paint("A"),
+            Color::Blue.paint("..."),
+            nu_ansi_term::Style::new().on(Color::Blue).paint("--"),
+            nu_ansi_term::Style::new().on(Color::Green).paint("B"),
         ])
         .to_string();
         assert_eq!(combined, expected);

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -16,6 +16,10 @@ pub struct TextSegment {
 }
 
 impl TextSegment {
+    fn style(&self, style_refs: Option<StyleRefs>) -> Option<AnsiStyle> {
+        self.style.map(|style| style.to_ansi_style(style_refs))
+    }
+
     // Returns the AnsiString of the segment value
     fn ansi_string(&self, style_refs: Option<StyleRefs>) -> AnsiString<'_> {
         match self.style {
@@ -37,7 +41,11 @@ pub struct FillSegment {
 
 impl FillSegment {
     pub fn style(&self) -> Option<AnsiStyle> {
-        self.style.map(|style| style.to_ansi_style(None))
+        self.style_with_refs(None)
+    }
+
+    pub fn style_with_refs(&self, style_refs: Option<StyleRefs>) -> Option<AnsiStyle> {
+        self.style.map(|style| style.to_ansi_style(style_refs))
     }
 
     // Returns the AnsiString of the segment value, not including its prefix and suffix
@@ -305,9 +313,14 @@ impl Segment {
     }
 
     pub fn style(&self) -> Option<AnsiStyle> {
+        self.style_with_prev(None)
+    }
+
+    pub fn style_with_prev(&self, prev_style: Option<AnsiStyle>) -> Option<AnsiStyle> {
+        let style_refs = StyleRefs::new(prev_style, None);
         match self {
-            Self::Fill(fs) => fs.style.map(|cs| cs.to_ansi_style(None)),
-            Self::Text(ts) => ts.style.map(|cs| cs.to_ansi_style(None)),
+            Self::Fill(fs) => fs.style_with_refs(Some(style_refs)),
+            Self::Text(ts) => ts.style(Some(style_refs)),
             Self::LineTerm => None,
         }
     }

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -36,6 +36,10 @@ pub struct FillSegment {
 }
 
 impl FillSegment {
+    pub fn style(&self) -> Option<AnsiStyle> {
+        self.style.map(|style| style.to_ansi_style(None))
+    }
+
     // Returns the AnsiString of the segment value, not including its prefix and suffix
     pub fn ansi_string(
         &self,
@@ -108,7 +112,7 @@ impl FillSegment {
 #[cfg(test)]
 mod fill_seg_tests {
     use super::FillSegment;
-    use crate::config::{StyleRefs, parse_style_string};
+    use crate::config::{parse_style_string, StyleRefs};
     use nu_ansi_term::Style as AnsiStyle;
     use nu_ansi_term::{AnsiStrings, Color};
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

Hi, I made a PR against your PR 😄 I hope you don't mind. Thanks for creating this, it's exactly what I was looking for.
I found a case I think that wasn't covered by your PR. Would you consider adding these two commits onto your PR?
One just adds a test for one of the fixes you made in your followup commits. The other one addresses a case where there is no fill style. Thanks for considering.

Fixes `next_fg` and `next_bg` resolution when a fill segment is immediately followed by another fill segment.
Adds regression coverage for missing style refs preserving fallback colors.

Concrete examples:

`fg:black fg:next_bg` now keeps `fg:black` when there is no next segment to read from, instead of clearing to the terminal default.
For adjacent fills like fill 1: f`g:next_bg` followed by fill 2: `bg:blue`, fill 1 now resolves to blue. Previously it only checked for text before fill 2, found none, and failed to use the adjacent fill’s background.

Example:

```
$directory\
$fill\
[<](fg:next_bg)\
$optional_module\
$fill\
[<](fg:next_bg)\
$time\
```

When `$optional_module` does not render, the two fill regions become adjacent. The first fill can now resolve `next_bg` from the next fill’s style instead of falling back to no color.

Tests:

```
cargo test --lib table_get_styles_keep_fallback_when_ref_side_is_missing
cargo test --lib test_fill_segment_resolves_next_style_from_adjacent_fill
```

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
